### PR TITLE
RHACM: Adding `policy-label-cluster`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Demonstrate aplication deployment throught RHACM
+# Demonstrating the deployment of the application through RHACM
 
 Demo showing the 2 possible ways (at the time of writing this) to deploy GitOps based applications thanks to Red Hat Advanced Cluster Management For Kubernetes (from now on, `ACM`).
 

--- a/rhacm/README.md
+++ b/rhacm/README.md
@@ -21,5 +21,6 @@ Policy  | Description | Prerequisites
 ------- | ----------- | -------------
 [Install OpenShift-Gitops](./grc/policies/CM-Configuration-Management/policy-openshift-gitops-operator-patched.yaml) | Use this policy to install the Red Hat OpenShift GitOps (Argo CD) | Requires OpenShift 4.x. Check the [documentation](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html/cicd/gitops) for more information.
 [Configuring Managed Clusters for OpenShift GitOps operator and Argo CD](./grc/policies/CM-Configuration-Management/policy-openshift-gitops-operator-patched.yaml) | Register a set of one or more ACM managed clusters to an instance of Argo CD | Requires OpenShift (*)
+[Configuring Managed Clusters for OpenShift GitOps operator and Argo CD](./grc/policies/CM-Configuration-Management/policy-label-cluster.yaml) | Adding cluster to **all-openshift-clusters** `ManagedClusterSet` | Just for `local-cluster`
 
 > ![NOTE](../images/note-icon.png) **(*) NOTE**: Only `OpenShift` clusters are registered to an `Argo CD`, not other Kubernetes clusters.

--- a/rhacm/grc/policies/CM-Configuration-Management/policy-label-cluster.yaml
+++ b/rhacm/grc/policies/CM-Configuration-Management/policy-label-cluster.yaml
@@ -1,0 +1,61 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: policy-label-cluster
+  annotations:
+    policy.open-cluster-management.io/standards: NIST-CSF
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-label-cluster
+        spec:
+          remediationAction: inform
+          severity: low
+          namespaceSelector:
+            exclude:
+              - kube-*
+            include:
+              - default
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: cluster.open-cluster-management.io/v1
+                kind: ManagedCluster
+                metadata:
+                  name: '{{hub .ManagedClusterName hub}}'
+                  labels:
+                    cluster.open-cluster-management.io/clusterset: all-openshift-clusters
+                spec:
+                  hubAcceptsClient: true
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: binding-policy-label-cluster
+placementRef:
+  name: placement-policy-label-cluster
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+- name: policy-label-cluster
+  kind: Policy
+  apiGroup: policy.open-cluster-management.io
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-policy-label-cluster
+spec:
+  clusterConditions:
+  - status: "True"
+    type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      - {key: name, operator: In, values: ["local-cluster"]}


### PR DESCRIPTION
RHACM: Adding `policy-label-cluster` that allow to add **local-cluster** to **all-openshift-clusters** `ManagedClusterSet`

Signed-off-by: Jose Antonio Gonzalez Prada <josgonza@redhat.com>